### PR TITLE
Remove duplicate OpenAI key line

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,7 +198,6 @@ def fuzzy_match(user_input, keywords, threshold=85):
     return False
 
 # -------- OPENAI SETUP --------
-openai.api_key = OPENAI_API_KEY
 client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
 functions = [


### PR DESCRIPTION
## Summary
- delete the redundant `openai.api_key` assignment

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68404a02e3ec8323bd7d1c049e42864a